### PR TITLE
feat: add DALL1xx for __dir__

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -153,13 +153,15 @@ To install with ``conda``:
 flake8 codes
 --------------
 
-============== =======================================
+============== ===============================================================
 Code           Description
-============== =======================================
+============== ===============================================================
 DALL000        Module lacks __all__.
 DALL001        __all__ not sorted alphabetically
 DALL002        __all__ not a list or tuple of strings.
-============== =======================================
+DALL100        Top-level __dir__ function definition is required.
+DALL101        Top-level __dir__ function definition is required in __init__.py.
+============== ===============================================================
 
 
 Use as a pre-commit hook

--- a/doc-source/usage.rst
+++ b/doc-source/usage.rst
@@ -14,6 +14,8 @@ Flake8 codes
 	DALL000
 	DALL001
 	DALL002
+	DALL100
+	DALL101
 
 
 For the ``DALL001`` option there exists a configuration option (``dunder-all-alphabetical``)
@@ -27,6 +29,7 @@ The options are:
 If the ``dunder-all-alphabetical`` option is omitted the ``DALL001`` check is disabled.
 
 .. versionchanged:: 0.5.0  Added the ``DALL001`` and ``DALL002`` checks.
+.. versionchanged:: 0.6.0  Added the ``DALL100`` and ``DALL101`` checks.
 
 .. note::
 

--- a/flake8_dunder_all/__init__.py
+++ b/flake8_dunder_all/__init__.py
@@ -97,6 +97,8 @@ class Visitor(ast.NodeVisitor):
 	.. versionchanged:: 0.5.0
 
 		Added the ``sorted_upper_first``, ``sorted_lower_first`` and ``all_lineno`` attributes.
+
+	.. versionchanged:: 0.6.0  Added the ``found_dir`` attribute.
 	"""
 
 	found_all: bool  #: Flag to indicate a ``__all__`` declaration has been found in the AST.
@@ -314,6 +316,8 @@ class Plugin:
 
 	:param tree: The abstract syntax tree (AST) to check.
 	:param filename: The filename being checked.
+
+	.. versionchanged:: 0.6.0  Added ``filename`` argument.
 	"""
 
 	name: str = __name__

--- a/flake8_dunder_all/__init__.py
+++ b/flake8_dunder_all/__init__.py
@@ -181,10 +181,6 @@ class Visitor(ast.NodeVisitor):
 		if not node.name.startswith('_') and "overload" not in decorators:
 			self.members.add(node.name)
 
-		if node.name == "__dir__":
-			self.found_dir = True
-			self.found_lineno = node.lineno
-
 	def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
 		"""
 		Visit ``def foo(): ...``.
@@ -194,6 +190,10 @@ class Visitor(ast.NodeVisitor):
 
 		# Don't generic visit
 		self.handle_def(node)
+
+		if node.name == "__dir__":
+			self.found_dir = True
+			self.found_lineno = node.lineno
 
 	def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
 		"""

--- a/flake8_dunder_all/__init__.py
+++ b/flake8_dunder_all/__init__.py
@@ -100,6 +100,7 @@ class Visitor(ast.NodeVisitor):
 	"""
 
 	found_all: bool  #: Flag to indicate a ``__all__`` declaration has been found in the AST.
+	found_dir: bool  #: Flag to indicate a top-level ``__dir__`` function has been found in the AST.
 	last_import: int  #: The lineno of the last top-level or conditional import
 	members: Set[str]  #: List of functions and classed defined in the AST
 	use_endlineno: bool
@@ -108,7 +109,6 @@ class Visitor(ast.NodeVisitor):
 
 	def __init__(self, use_endlineno: bool = False) -> None:
 		self.found_all = False
-		self.found_lineno = -1
 		self.found_dir = False
 		self.members = set()
 		self.last_import = 0
@@ -193,7 +193,6 @@ class Visitor(ast.NodeVisitor):
 
 		if node.name == "__dir__":
 			self.found_dir = True
-			self.found_lineno = node.lineno
 
 	def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
 		"""
@@ -360,17 +359,13 @@ class Plugin:
 				if list(visitor.all_members) != sorted_alphabetical:
 					yield visitor.all_lineno, 0, f"{DALL001} (lowercase first).", type(self)
 
-		elif not visitor.members:
-			pass
-
-		else:
+		elif visitor.members:
 			yield 1, 0, DALL000, type(self)
 
-		# Require top-level __dir__ function
-		if not visitor.found_dir:
+		# Require a top-level __dir__, but only when the module defines public members
+		if visitor.members and not visitor.found_dir:
 			if self._filename.endswith("__init__.py"):
-				if visitor.members:
-					yield 1, 0, DALL101, type(self)
+				yield 1, 0, DALL101, type(self)
 			else:
 				yield 1, 0, DALL100, type(self)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -7,7 +7,7 @@ from flake8_dunder_all import Plugin
 
 
 def results(s: str) -> Set[str]:
-	return {"{}:{}: {}".format(*r) for r in Plugin(ast.parse(s)).run()}
+	return {"{}:{}: {}".format(*r) for r in Plugin(ast.parse(s), "mod.py").run() if "DALL0" in r[2]}
 
 
 testing_source_a = '''

--- a/tests/common.py
+++ b/tests/common.py
@@ -7,7 +7,7 @@ from flake8_dunder_all import Plugin
 
 
 def results(s: str) -> Set[str]:
-	return {"{}:{}: {}".format(*r) for r in Plugin(ast.parse(s), "mod.py").run() if "DALL0" in r[2]}
+	return {"{}:{}: {}".format(*r) for r in Plugin(ast.parse(s), "mod.py").run() if r[2].startswith("DALL0")}
 
 
 testing_source_a = '''

--- a/tests/test_dir_required.py
+++ b/tests/test_dir_required.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+# stdlib
+import ast
+import inspect
+from typing import Any
+
+# this package
+from flake8_dunder_all import Plugin
+
+
+def from_source(source: str, filename: str) -> list[tuple[int, int, str, type[Any]]]:
+	source_clean = inspect.cleandoc(source)
+	plugin = Plugin(ast.parse(source_clean), filename)
+	return list(plugin.run())
+
+
+def test_dir_required_non_init():
+	source = """
+	import foo
+	"""
+	results = from_source(source, "module.py")
+	assert any("DALL100" in r[2] for r in results)
+
+
+def test_dir_required_non_init_with_dir():
+	# __dir__ defined, should not yield DALL100
+	source_with_dir = """
+	def __dir__():
+		return []\n"""
+	results = from_source(source_with_dir, "module.py")
+	assert not any("DALL100" in r[2] for r in results)
+
+
+def test_dir_required_empty():
+	source = """\nimport foo\n"""
+	# No __dir__ defined but no members present, should not yield DALL101
+	results = from_source(source, "__init__.py")
+	assert not any("DALL101" in r[2] for r in results)
+
+
+def test_dir_required_init():
+	source = """\nimport foo\n\nclass Foo: ...\n"""
+	# No __dir__ defined, should yield DALL101
+	results = from_source(source, "__init__.py")
+	assert any("DALL101" in r[2] for r in results)
+
+
+def test_dir_required_init_with_dir():
+	# __dir__ defined, should not yield DALL101
+	source_with_dir = """\ndef __dir__():\n	return []\n"""
+	results = from_source(source_with_dir, "__init__.py")
+	assert not any("DALL101" in r[2] for r in results)

--- a/tests/test_dir_required.py
+++ b/tests/test_dir_required.py
@@ -51,3 +51,26 @@ def test_dir_required_init_with_dir():
 	source_with_dir = """\ndef __dir__():\n	return []\n"""
 	results = from_source(source_with_dir, "__init__.py")
 	assert not any("DALL101" in r[2] for r in results)
+
+
+def test_dir_required_async_def_does_not_satisfy():
+	# ``async def __dir__`` can't be used by ``dir(module)``, so DALL100 still applies
+	source = """
+	import foo
+
+	async def __dir__():
+		return []
+	"""
+	results = from_source(source, "module.py")
+	assert any("DALL100" in r[2] for r in results)
+
+
+def test_dir_required_class_does_not_satisfy():
+	# ``class __dir__`` can't be used by ``dir(module)``, so DALL100 still applies
+	source = """
+	import foo
+
+	class __dir__: ...
+	"""
+	results = from_source(source, "module.py")
+	assert any("DALL100" in r[2] for r in results)

--- a/tests/test_dir_required.py
+++ b/tests/test_dir_required.py
@@ -18,6 +18,8 @@ def from_source(source: str, filename: str) -> list[tuple[int, int, str, type[An
 def test_dir_required_non_init():
 	source = """
 	import foo
+
+	class Foo: ...
 	"""
 	results = from_source(source, "module.py")
 	assert any("DALL100" in r[2] for r in results)
@@ -26,15 +28,25 @@ def test_dir_required_non_init():
 def test_dir_required_non_init_with_dir():
 	# __dir__ defined, should not yield DALL100
 	source_with_dir = """
+	class Foo: ...
+
 	def __dir__():
-		return []\n"""
+		return []
+	"""
 	results = from_source(source_with_dir, "module.py")
 	assert not any("DALL100" in r[2] for r in results)
 
 
 def test_dir_required_empty():
+	# No public members, so __dir__ is not required
 	source = """\nimport foo\n"""
-	# No __dir__ defined but no members present, should not yield DALL101
+	results = from_source(source, "module.py")
+	assert not any("DALL100" in r[2] for r in results)
+
+
+def test_dir_required_empty_init():
+	# No public members, so __dir__ is not required in __init__.py either
+	source = """\nimport foo\n"""
 	results = from_source(source, "__init__.py")
 	assert not any("DALL101" in r[2] for r in results)
 
@@ -48,7 +60,12 @@ def test_dir_required_init():
 
 def test_dir_required_init_with_dir():
 	# __dir__ defined, should not yield DALL101
-	source_with_dir = """\ndef __dir__():\n	return []\n"""
+	source_with_dir = """
+	class Foo: ...
+
+	def __dir__():
+		return []
+	"""
 	results = from_source(source_with_dir, "__init__.py")
 	assert not any("DALL101" in r[2] for r in results)
 
@@ -57,6 +74,8 @@ def test_dir_required_async_def_does_not_satisfy():
 	# ``async def __dir__`` can't be used by ``dir(module)``, so DALL100 still applies
 	source = """
 	import foo
+
+	class Foo: ...
 
 	async def __dir__():
 		return []
@@ -69,6 +88,8 @@ def test_dir_required_class_does_not_satisfy():
 	# ``class __dir__`` can't be used by ``dir(module)``, so DALL100 still applies
 	source = """
 	import foo
+
+	class Foo: ...
 
 	class __dir__: ...
 	"""

--- a/tests/test_flake8_dunder_all.py
+++ b/tests/test_flake8_dunder_all.py
@@ -135,9 +135,9 @@ def test_plugin(source: str, expects: Set[str]):
 				],
 		)
 def test_plugin_alphabetical(source: str, expects: Set[str], dunder_all_alphabetical: AlphabeticalOptions):
-	plugin = Plugin(ast.parse(source))
+	plugin = Plugin(ast.parse(source), "mod.py")
 	plugin.dunder_all_alphabetical = dunder_all_alphabetical
-	assert {"{}:{}: {}".format(*r) for r in plugin.run()} == expects
+	assert {"{}:{}: {}".format(*r) for r in plugin.run() if "DALL0" in r[2]} == expects
 
 
 @pytest.mark.parametrize(
@@ -210,9 +210,9 @@ def test_plugin_alphabetical_ann_assign(
 		expects: Set[str],
 		dunder_all_alphabetical: AlphabeticalOptions,
 		):
-	plugin = Plugin(ast.parse(source))
+	plugin = Plugin(ast.parse(source), "mod.py")
 	plugin.dunder_all_alphabetical = dunder_all_alphabetical
-	assert {"{}:{}: {}".format(*r) for r in plugin.run()} == expects
+	assert {"{}:{}: {}".format(*r) for r in plugin.run() if "DALL0" in r[2]} == expects
 
 
 @pytest.mark.parametrize(
@@ -229,16 +229,16 @@ def test_plugin_alphabetical_ann_assign(
 				],
 		)
 def test_plugin_alphabetical_not_list(source: str, dunder_all_alphabetical: AlphabeticalOptions):
-	plugin = Plugin(ast.parse(source))
+	plugin = Plugin(ast.parse(source), "mod.py")
 	plugin.dunder_all_alphabetical = dunder_all_alphabetical
 	msg = "1:0: DALL002 __all__ not a list or tuple of strings."
-	assert {"{}:{}: {}".format(*r) for r in plugin.run()} == {msg}
+	assert {"{}:{}: {}".format(*r) for r in plugin.run() if "DALL0" in r[2]} == {msg}
 
 
 def test_plugin_alphabetical_tuple():
-	plugin = Plugin(ast.parse("__all__ = ('bar',\n'foo')"))
+	plugin = Plugin(ast.parse("__all__ = ('bar',\n'foo')"), "mod.py")
 	plugin.dunder_all_alphabetical = AlphabeticalOptions.IGNORE
-	assert {"{}:{}: {}".format(*r) for r in plugin.run()} == set()
+	assert {"{}:{}: {}".format(*r) for r in plugin.run() if "DALL0" in r[2]} == set()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_flake8_dunder_all.py
+++ b/tests/test_flake8_dunder_all.py
@@ -137,7 +137,7 @@ def test_plugin(source: str, expects: Set[str]):
 def test_plugin_alphabetical(source: str, expects: Set[str], dunder_all_alphabetical: AlphabeticalOptions):
 	plugin = Plugin(ast.parse(source), "mod.py")
 	plugin.dunder_all_alphabetical = dunder_all_alphabetical
-	assert {"{}:{}: {}".format(*r) for r in plugin.run() if "DALL0" in r[2]} == expects
+	assert {"{}:{}: {}".format(*r) for r in plugin.run() if r[2].startswith("DALL0")} == expects
 
 
 @pytest.mark.parametrize(
@@ -212,7 +212,7 @@ def test_plugin_alphabetical_ann_assign(
 		):
 	plugin = Plugin(ast.parse(source), "mod.py")
 	plugin.dunder_all_alphabetical = dunder_all_alphabetical
-	assert {"{}:{}: {}".format(*r) for r in plugin.run() if "DALL0" in r[2]} == expects
+	assert {"{}:{}: {}".format(*r) for r in plugin.run() if r[2].startswith("DALL0")} == expects
 
 
 @pytest.mark.parametrize(
@@ -232,13 +232,13 @@ def test_plugin_alphabetical_not_list(source: str, dunder_all_alphabetical: Alph
 	plugin = Plugin(ast.parse(source), "mod.py")
 	plugin.dunder_all_alphabetical = dunder_all_alphabetical
 	msg = "1:0: DALL002 __all__ not a list or tuple of strings."
-	assert {"{}:{}: {}".format(*r) for r in plugin.run() if "DALL0" in r[2]} == {msg}
+	assert {"{}:{}: {}".format(*r) for r in plugin.run() if r[2].startswith("DALL0")} == {msg}
 
 
 def test_plugin_alphabetical_tuple():
 	plugin = Plugin(ast.parse("__all__ = ('bar',\n'foo')"), "mod.py")
 	plugin.dunder_all_alphabetical = AlphabeticalOptions.IGNORE
-	assert {"{}:{}: {}".format(*r) for r in plugin.run() if "DALL0" in r[2]} == set()
+	assert {"{}:{}: {}".format(*r) for r in plugin.run() if r[2].startswith("DALL0")} == set()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -66,7 +66,7 @@ def test_subprocess_noqa(tmp_pathplus: PathPlus, monkeypatch):
 	monkeypatch.delenv("COV_CORE_DATAFILE", raising=False)
 	monkeypatch.setenv("PYTHONWARNINGS", "ignore")
 
-	(tmp_pathplus / "demo.py").write_text("  # noqa: DALL000,DALL100  \n\n\t\ndef foo():\n\tpass\n\t")
+	(tmp_pathplus / "demo.py").write_text("  # noq" + "a: DALL000,DALL100  \n\n\t\ndef foo():\n\tpass\n\t")
 
 	with in_directory(tmp_pathplus):
 		result = subprocess.run(

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -66,7 +66,7 @@ def test_subprocess_noqa(tmp_pathplus: PathPlus, monkeypatch):
 	monkeypatch.delenv("COV_CORE_DATAFILE", raising=False)
 	monkeypatch.setenv("PYTHONWARNINGS", "ignore")
 
-	(tmp_pathplus / "demo.py").write_text("# noq" + "a: DALL000\n\n\t\ndef foo():\n\tpass\n\t")
+	(tmp_pathplus / "demo.py").write_text("  # noqa: DALL000,DALL100  \n\n\t\ndef foo():\n\tpass\n\t")
 
 	with in_directory(tmp_pathplus):
 		result = subprocess.run(


### PR DESCRIPTION
Close #86.

Adds a check for `__dir__`, split into two codes (one for `__init__`). The `__init__` check will not trigger unless something is defined in init.
